### PR TITLE
stats: pass along all OpenCensus tags to Datadog

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -119,12 +119,12 @@ func viewSignature(namespace string, v *view.View) string {
 
 // tagMetrics concatenates user input custom tags with row tags
 func (o *Options) tagMetrics(rowTags []tag.Tag, addlTags []string) []string {
-	customTags := o.Tags
-	var finaltag []string
+	finalTags := make([]string, len(o.Tags), len(o.Tags)+len(rowTags)+len(addlTags))
+	copy(finalTags, o.Tags)
 	for key := range rowTags {
-		finaltag = append(customTags,
+		finalTags = append(finalTags,
 			rowTags[key].Key.Name()+":"+rowTags[key].Value)
 	}
-	finaltag = append(finaltag, addlTags...)
-	return finaltag
+	finalTags = append(finalTags, addlTags...)
+	return finalTags
 }

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -127,10 +127,12 @@ func TestSignature(t *testing.T) {
 func TestTagMetrics(t *testing.T) {
 	o := Options{}
 	key, _ := tag.NewKey("testTags")
-	tags := []tag.Tag{tag.Tag{Key: key, Value: "Metrics"}}
+	key2, _ := tag.NewKey("testTags2")
+
+	tags := []tag.Tag{tag.Tag{Key: key, Value: "Metrics"}, tag.Tag{Key: key2, Value: "Metrics"}}
 	customTag := []string{"program_name:main"}
 	result := o.tagMetrics(tags, customTag)
-	expected := []string{"testTags:Metrics", "program_name:main"}
+	expected := []string{"testTags:Metrics", "testTags2:Metrics", "program_name:main"}
 
 	if n := len(expected); n == 0 {
 		t.Fatal("got 0")
@@ -185,7 +187,7 @@ func TestCountData(t *testing.T) {
 	<-time.After(10 * time.Millisecond)
 
 	actual := exporter.view("fooCount")
-	if actual != vd {
+	if !reflect.DeepEqual(*actual, *vd) {
 		t.Errorf("Expected: %v, Got: %v\n", vd, actual)
 	}
 }


### PR DESCRIPTION
Currently, when the `tagMetrics` method is run to format and concatenate the list of global tags and OpenCensus tags, we end up chopping off every OpenCensus tag except for the last one.

This PR does a few things:
- Update `tagMetrics` to not truncate the list of OpenCensus tags
- Update unit tests to test for the case outlined above
- Update `tagMetrics` to be a bit more efficient in how we generate tag slices. Since we're working with metrics that could be sent over very frequently, shaving off a few cycles could be a good performance improvement
- Fix a flaky unit test that was comparing two pointers