### PR TITLE
Unify resource name of the top-level span within the same service

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -55,6 +55,9 @@ type Options struct {
 	// Service specifies the service name used for tracing.
 	Service string
 
+	// RootResourceName specifies the resource name of the top level span
+	RootResourceName string
+
 	// TraceAddr specifies the host[:port] address of the Datadog Trace Agent.
 	// It defaults to localhost:8126.
 	TraceAddr string

--- a/span.go
+++ b/span.go
@@ -59,6 +59,8 @@ func (e *traceExporter) convertSpan(s *trace.SpanData) *ddSpan {
 	}
 	if s.ParentSpanID != (trace.SpanID{}) {
 		span.ParentID = binary.BigEndian.Uint64(s.ParentSpanID[:])
+	} else if e.opts.RootResourceName != "" {
+		span.Resource = e.opts.RootResourceName
 	}
 	switch s.SpanKind {
 	case trace.SpanKindClient:

--- a/span_test.go
+++ b/span_test.go
@@ -182,6 +182,34 @@ func TestConvertSpan(t *testing.T) {
 	}
 }
 
+func TestConvertSpanWithRootResourceName(t *testing.T) {
+	service := "my-service"
+	resource := "my-resource"
+	e := newTraceExporter(Options{Service: service, RootResourceName: resource})
+
+	{
+		name := "root"
+		tt := spanPairs[name]
+		t.Run(name, func(t *testing.T) {
+			want := *tt.dd
+			want.Resource = resource
+			if got := e.convertSpan(tt.oc); !reflect.DeepEqual(got, &want) {
+				t.Fatalf("\nGot:\n%#v\n\nWant:\n%#v\n", got, &want)
+			}
+		})
+	}
+
+	{
+		name := "child"
+		tt := spanPairs[name]
+		t.Run(name, func(t *testing.T) {
+			if got := e.convertSpan(tt.oc); !reflect.DeepEqual(got, tt.dd) {
+				t.Fatalf("\nGot:\n%#v\n\nWant:\n%#v\n", got, tt.dd)
+			}
+		})
+	}
+}
+
 func TestSetError(t *testing.T) {
 	for i, tt := range [...]struct {
 		val interface{} // error value


### PR DESCRIPTION
The APM requires the service has unique resource name in the top-level span.
Currently, this package uses the span name as the resource name. Although, some package sends various span name. For example, [ochttp](https://godoc.org/go.opencensus.io/plugin/ochttp) treats the request/response URL as the span name, so the resource names are different in the same service.