### PR TITLE
trace: add GlobalTags support

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -69,6 +69,10 @@ type Options struct {
 
 	// Tags specifies a set of global tags to attach to each metric.
 	Tags []string
+
+	// GlobalTags holds a set of tags that will automatically be applied to all
+	// exported spans.
+	GlobalTags map[string]interface{}
 }
 
 func (o *Options) onError(err error) {

--- a/span.go
+++ b/span.go
@@ -75,6 +75,9 @@ func (e *traceExporter) convertSpan(s *trace.SpanData) *ddSpan {
 	if msg := s.Status.Message; msg != "" {
 		span.Meta[statusKey] = msg
 	}
+	for key, val := range e.opts.GlobalTags {
+		setTag(span, key, val)
+	}
 	for key, val := range s.Attributes {
 		setTag(span, key, val)
 	}

--- a/span_test.go
+++ b/span_test.go
@@ -173,12 +173,27 @@ var spanPairs = map[string]struct {
 func TestConvertSpan(t *testing.T) {
 	service := "my-service"
 	e := newTraceExporter(Options{Service: service})
+	defer e.stop()
+
 	for name, tt := range spanPairs {
 		t.Run(name, func(t *testing.T) {
 			if got := e.convertSpan(tt.oc); !reflect.DeepEqual(got, tt.dd) {
 				t.Fatalf("\nGot:\n%#v\n\nWant:\n%#v\n", got, tt.dd)
 			}
 		})
+	}
+}
+
+func TestGlobalTags(t *testing.T) {
+	e := newTraceExporter(Options{
+		Service:    "my-service",
+		GlobalTags: map[string]interface{}{"key1": "value1"},
+	})
+	defer e.stop()
+
+	got := e.convertSpan(spanPairs["tags"].oc)
+	if got.Meta["key1"] != "value1" {
+		t.Fatal("global tag not set")
 	}
 }
 


### PR DESCRIPTION
Add default Tags option for all span like ddtracer's `WithGlobalTags` option.

I want to populate "env" tag for all spans. OpenCesus seems to recommend default tags feature is implemeneted in exporter side.