### PR TITLE
stats: call onError for submitMetric errors.

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -49,14 +49,14 @@ func (s *statsExporter) addViewData(vd *view.Data) {
 	s.viewData[sig] = vd
 	s.mu.Unlock()
 
-	var err error
+	var lastErr error
 	for _, row := range vd.Rows {
-		if e := s.submitMetric(vd.View, row, sig); e != nil {
-			err = e
+		if err := s.submitMetric(vd.View, row, sig); err != nil {
+			lastErr = err
 		}
 	}
-	if err != nil {
-		s.opts.onError(err) // Only report last error.
+	if lastErr != nil {
+		s.opts.onError(lastErr) // Only report last error.
 	}
 }
 

--- a/stats.go
+++ b/stats.go
@@ -49,8 +49,14 @@ func (s *statsExporter) addViewData(vd *view.Data) {
 	s.viewData[sig] = vd
 	s.mu.Unlock()
 
+	var err error
 	for _, row := range vd.Rows {
-		s.submitMetric(vd.View, row, sig)
+		if e := s.submitMetric(vd.View, row, sig); e != nil {
+			err = e
+		}
+	}
+	if err != nil {
+		s.opts.onError(err) // Only report last error.
 	}
 }
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -41,6 +41,32 @@ func TestAddViewData(t *testing.T) {
 	}
 }
 
+func TestUDSExportError(t *testing.T) {
+	var expected error
+
+	exporter := testExporter(Options{
+		StatsAddr: "unix:///invalid.socket", // Ideally we wwouln't hit the filesystem.
+		OnError: func(err error) {
+			expected = err
+		},
+	})
+
+	data := &view.Data{
+		View: newView(view.Count()),
+		Rows: []*view.Row{
+			{
+				Tags: []tag.Tag{},
+				Data: &view.CountData{},
+			},
+		},
+	}
+	exporter.statsExporter.addViewData(data)
+
+	if expected == nil {
+		t.Errorf("Expected an error")
+	}
+}
+
 func TestNilAggregation(t *testing.T) {
 	exporter := testExporter(Options{})
 	noneAgg := &view.Aggregation{


### PR DESCRIPTION
Currently traces uploads call onError but statistic silently fail, if using UDS and the socket is not available an error is expected.