### PR TITLE
stats: expose UDP address errors on exporter initialize

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -86,11 +86,16 @@ func (o *Options) onError(err error) {
 // NewExporter returns an exporter that exports stats and traces to Datadog.
 // When using trace, it is important to call Stop at the end of your program
 // for a clean exit and to flush any remaining tracing data to the Datadog agent.
-func NewExporter(o Options) *Exporter {
-	return &Exporter{
-		statsExporter: newStatsExporter(o),
-		traceExporter: newTraceExporter(o),
+func NewExporter(o Options) (exporter *Exporter, err error) {
+	statsExporter, err := newStatsExporter(o)
+	if err != nil {
+		return
 	}
+
+	return &Exporter{
+		statsExporter: statsExporter,
+		traceExporter: newTraceExporter(o),
+	}, nil
 }
 
 // regex pattern

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -51,7 +51,10 @@ func newCustomView(measureName string, agg *view.Aggregation, tags []tag.Key, me
 
 func TestExportView(t *testing.T) {
 	reportPeriod := time.Millisecond
-	exporter := testExporter(Options{})
+	exporter, err := testExporter(Options{})
+	if err != nil {
+		t.Error(err)
+	}
 
 	vd := newCustomView("fooCount", view.Count(), testTags, measureCount)
 	if err := view.Register(vd); err != nil {
@@ -172,7 +175,10 @@ func TestOnErrorNil(t *testing.T) {
 
 func TestCountData(t *testing.T) {
 	reportPeriod := time.Millisecond
-	exporter := testExporter(Options{})
+	exporter, err := testExporter(Options{})
+	if err != nil {
+		t.Error(err)
+	}
 
 	vd := newCustomView("fooCount", view.Count(), testTags, measureCount)
 	if err := view.Register(vd); err != nil {
@@ -194,7 +200,10 @@ func TestCountData(t *testing.T) {
 
 func TestSumData(t *testing.T) {
 	reportPeriod := time.Millisecond
-	exporter := testExporter(Options{})
+	exporter, err := testExporter(Options{})
+	if err != nil {
+		t.Error(err)
+	}
 
 	vd := newCustomView("fooSum", view.Sum(), testTags, measureSum)
 	if err := view.Register(vd); err != nil {
@@ -216,7 +225,10 @@ func TestSumData(t *testing.T) {
 
 func TestLastValueData(t *testing.T) {
 	reportPeriod := time.Millisecond
-	exporter := testExporter(Options{})
+	exporter, err := testExporter(Options{})
+	if err != nil {
+		t.Error(err)
+	}
 
 	vd := newCustomView("fooLast", view.LastValue(), testTags, measureLast)
 	if err := view.Register(vd); err != nil {
@@ -238,7 +250,10 @@ func TestLastValueData(t *testing.T) {
 
 func TestHistogram(t *testing.T) {
 	reportPeriod := time.Millisecond
-	exporter := testExporter(Options{})
+	exporter, err := testExporter(Options{})
+	if err != nil {
+		t.Error(err)
+	}
 
 	vd := newCustomView("fooHisto", view.Distribution(), testTags, measureDist)
 	if err := view.Register(vd); err != nil {

--- a/stats.go
+++ b/stats.go
@@ -7,7 +7,6 @@ package datadog
 
 import (
 	"fmt"
-	"log"
 	"sync"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -33,7 +32,7 @@ type statsExporter struct {
 	viewData map[string]*view.Data
 }
 
-func newStatsExporter(o Options) *statsExporter {
+func newStatsExporter(o Options) (*statsExporter, error) {
 	endpoint := o.StatsAddr
 	if endpoint == "" {
 		endpoint = DefaultStatsAddrUDP
@@ -41,14 +40,14 @@ func newStatsExporter(o Options) *statsExporter {
 
 	client, err := statsd.New(endpoint)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	return &statsExporter{
 		opts:     o,
 		viewData: make(map[string]*view.Data),
 		client:   client,
-	}
+	}, nil
 }
 
 func (s *statsExporter) addViewData(vd *view.Data) {

--- a/stats_test.go
+++ b/stats_test.go
@@ -22,15 +22,22 @@ func (e *testStatsExporter) view(name string) *view.View {
 	return e.Exporter.statsExporter.viewData[name].View
 }
 
-func testExporter(opts Options) *testStatsExporter {
-	e := NewExporter(opts)
+func testExporter(opts Options) (*testStatsExporter, error) {
+	e, err := NewExporter(opts)
+	if err != nil {
+		return nil, err
+	}
 	view.RegisterExporter(e)
 	view.SetReportingPeriod(time.Millisecond)
-	return &testStatsExporter{e}
+	return &testStatsExporter{e}, nil
 }
 
 func TestAddViewData(t *testing.T) {
-	exporter := testExporter(Options{Namespace: "hello", Tags: []string{"test:optionalTag"}})
+	exporter, err := testExporter(Options{Namespace: "hello", Tags: []string{"test:optionalTag"}})
+	if err != nil {
+		t.Error(err)
+	}
+
 	expected := &view.Data{
 		View: newView(view.Count()),
 	}
@@ -41,15 +48,28 @@ func TestAddViewData(t *testing.T) {
 	}
 }
 
+func TestUDPExportError(t *testing.T) {
+	_, err := testExporter(Options{
+		StatsAddr: "invalid_address",
+	})
+
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+}
+
 func TestUDSExportError(t *testing.T) {
 	var expected error
 
-	exporter := testExporter(Options{
+	exporter, err := testExporter(Options{
 		StatsAddr: "unix:///invalid.socket", // Ideally we wwouln't hit the filesystem.
 		OnError: func(err error) {
 			expected = err
 		},
 	})
+	if err != nil {
+		t.Error(err)
+	}
 
 	data := &view.Data{
 		View: newView(view.Count()),
@@ -68,7 +88,11 @@ func TestUDSExportError(t *testing.T) {
 }
 
 func TestNilAggregation(t *testing.T) {
-	exporter := testExporter(Options{})
+	exporter, err := testExporter(Options{})
+	if err != nil {
+		t.Error(err)
+	}
+
 	noneAgg := &view.Aggregation{
 		Type:    view.AggTypeNone,
 		Buckets: []float64{1},


### PR DESCRIPTION
This is an API breaking change.

Fixes: https://github.com/DataDog/opencensus-go-exporter-datadog/issues/18