### PR TITLE
trace: use /v0.4 agent endpoint and priority sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,10 @@ provides some simple usage examples.
 
 ### Disclaimer
 
-For trace, this package is considered experiemental and comes with limitations. More specifically, due to the differences in operation between Datadog and OpenCensus, statistics (such as percentiles) seen in the Datadog application will be inaccurate and will be limited to only sampled traces. It is not advised to rely on these numbers to assert accurate system behaviour.  We are aware of the issue and the situation could change in the near future.
+In order to get accurate Datadog APM statistics and full distributed tracing, trace sampling must be done by the Datadog stack. For this to be possible, OpenCensus must be notified to forward all traces to our exporter:
+
+```go
+trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+```
+
+This change simply means that Datadog will handle sampling. It does not mean that all traces will be sampled.

--- a/sampler.go
+++ b/sampler.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadog.com/).
+// Copyright 2018 Datadog, Inc.
+
+package datadog
+
+import (
+	"encoding/json"
+	"io"
+	"math"
+	"sync"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+)
+
+// constants used for the Knuth hashing, same as agent.
+const knuthFactor = uint64(1111111111111111111)
+
+// sampledByRate verifies if the number n should be sampled at the specified
+// rate.
+func sampledByRate(n uint64, rate float64) bool {
+	if rate < 1 {
+		return n*knuthFactor < uint64(rate*math.MaxUint64)
+	}
+	return true
+}
+
+// prioritySampler holds a set of per-service sampling rates and applies
+// them to spans.
+type prioritySampler struct {
+	mu          sync.RWMutex
+	rates       map[string]float64
+	defaultRate float64
+}
+
+func newPrioritySampler() *prioritySampler {
+	return &prioritySampler{
+		rates:       make(map[string]float64),
+		defaultRate: 1.,
+	}
+}
+
+// readRatesJSON will try to read the rates as JSON from the given io.ReadCloser.
+func (ps *prioritySampler) readRatesJSON(rc io.ReadCloser) error {
+	var payload struct {
+		Rates map[string]float64 `json:"rate_by_service"`
+	}
+	if err := json.NewDecoder(rc).Decode(&payload); err != nil {
+		return err
+	}
+	rc.Close()
+	const defaultRateKey = "service:,env:"
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.rates = payload.Rates
+	if v, ok := ps.rates[defaultRateKey]; ok {
+		ps.defaultRate = v
+		delete(ps.rates, defaultRateKey)
+	}
+	return nil
+}
+
+// getRate returns the sampling rate to be used for the given span. Callers must
+// guard the span.
+func (ps *prioritySampler) getRate(spn *ddSpan) float64 {
+	key := "service:" + spn.Service + ",env:" + spn.Meta[ext.Environment]
+	ps.mu.RLock()
+	defer ps.mu.RUnlock()
+	if rate, ok := ps.rates[key]; ok {
+		return rate
+	}
+	return ps.defaultRate
+}
+
+// apply applies sampling priority to the given span. Caller must ensure it is safe
+// to modify the span.
+func (ps *prioritySampler) apply(spn *ddSpan) {
+	rate := ps.getRate(spn)
+	if sampledByRate(spn.TraceID, rate) {
+		spn.Metrics[samplingPriorityKey] = ext.PriorityAutoKeep
+	} else {
+		spn.Metrics[samplingPriorityKey] = ext.PriorityAutoReject
+	}
+	spn.Metrics[samplingPriorityRateKey] = rate
+}

--- a/sampler.go
+++ b/sampler.go
@@ -75,7 +75,7 @@ func (ps *prioritySampler) getRate(spn *ddSpan) float64 {
 
 // apply applies sampling priority to the given span. Caller must ensure it is safe
 // to modify the span.
-func (ps *prioritySampler) apply(spn *ddSpan) {
+func (ps *prioritySampler) applyPriority(spn *ddSpan) {
 	rate := ps.getRate(spn)
 	if sampledByRate(spn.TraceID, rate) {
 		spn.Metrics[samplingPriorityKey] = ext.PriorityAutoKeep

--- a/sampler.go
+++ b/sampler.go
@@ -61,8 +61,7 @@ func (ps *prioritySampler) readRatesJSON(rc io.ReadCloser) error {
 	return nil
 }
 
-// getRate returns the sampling rate to be used for the given span. Callers must
-// guard the span.
+// getRate returns the sampling rate to be used for the given span.
 func (ps *prioritySampler) getRate(spn *ddSpan) float64 {
 	key := "service:" + spn.Service + ",env:" + spn.Meta[ext.Environment]
 	ps.mu.RLock()
@@ -73,14 +72,13 @@ func (ps *prioritySampler) getRate(spn *ddSpan) float64 {
 	return ps.defaultRate
 }
 
-// apply applies sampling priority to the given span. Caller must ensure it is safe
-// to modify the span.
+// applyPriority applies sampling priority to the given ddSpan.
 func (ps *prioritySampler) applyPriority(spn *ddSpan) {
 	rate := ps.getRate(spn)
 	if sampledByRate(spn.TraceID, rate) {
-		spn.Metrics[samplingPriorityKey] = ext.PriorityAutoKeep
+		spn.Metrics[keySamplingPriority] = ext.PriorityAutoKeep
 	} else {
-		spn.Metrics[samplingPriorityKey] = ext.PriorityAutoReject
+		spn.Metrics[keySamplingPriority] = ext.PriorityAutoReject
 	}
-	spn.Metrics[samplingPriorityRateKey] = rate
+	spn.Metrics[keySamplingPriorityRate] = rate
 }

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -151,17 +151,17 @@ func TestPrioritySampler(t *testing.T) {
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 4)
 
 		ps.applyPriority(testSpan1)
-		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 3)
 		ps.applyPriority(testSpan1)
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 
 		testSpan1.Service = "other-service"
 		testSpan1.TraceID = 1
-		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
-		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[keySamplingPriority])
+		assert.EqualValues(0.5, testSpan1.Metrics[keySamplingPriorityRate])
 	})
 }

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -150,12 +150,12 @@ func TestPrioritySampler(t *testing.T) {
 		testSpan1.Service = "obfuscate.http"
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 4)
 
-		ps.apply(testSpan1)
+		ps.applyPriority(testSpan1)
 		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[samplingPriorityKey])
 		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
 
 		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 3)
-		ps.apply(testSpan1)
+		ps.applyPriority(testSpan1)
 		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
 		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
 

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadog.com/).
+// Copyright 2018 Datadog, Inc.
+
+package datadog
+
+import (
+	"io/ioutil"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrioritySampler(t *testing.T) {
+	// create a new span with given service/env
+	mkSpan := func(svc, env string) *ddSpan {
+		s := &ddSpan{Service: svc, Meta: map[string]string{}}
+		if env != "" {
+			s.Meta["env"] = env
+		}
+		return s
+	}
+
+	t.Run("mkspan", func(t *testing.T) {
+		assert := assert.New(t)
+		s := mkSpan("my-service", "my-env")
+		assert.Equal("my-service", s.Service)
+		assert.Equal("my-env", s.Meta[ext.Environment])
+
+		s = mkSpan("my-service2", "")
+		assert.Equal("my-service2", s.Service)
+		_, ok := s.Meta[ext.Environment]
+		assert.False(ok)
+	})
+
+	t.Run("ops", func(t *testing.T) {
+		ps := newPrioritySampler()
+		assert := assert.New(t)
+
+		type key struct{ service, env string }
+		for _, tt := range []struct {
+			in  string
+			out map[key]float64
+		}{
+			{
+				in: `{}`,
+				out: map[key]float64{
+					key{"some-service", ""}:       1,
+					key{"obfuscate.http", "none"}: 1,
+				},
+			},
+			{
+				in: `{
+					"rate_by_service":{
+						"service:,env:":0.8,
+						"service:obfuscate.http,env:":0.9,
+						"service:obfuscate.http,env:none":0.9
+					}
+				}`,
+				out: map[key]float64{
+					key{"obfuscate.http", ""}:      0.9,
+					key{"obfuscate.http", "none"}:  0.9,
+					key{"obfuscate.http", "other"}: 0.8,
+					key{"some-service", ""}:        0.8,
+				},
+			},
+			{
+				in: `{
+					"rate_by_service":{
+						"service:my-service,env:":0.2,
+						"service:my-service,env:none":0.2
+					}
+				}`,
+				out: map[key]float64{
+					key{"my-service", ""}:          0.2,
+					key{"my-service", "none"}:      0.2,
+					key{"obfuscate.http", ""}:      0.8,
+					key{"obfuscate.http", "none"}:  0.8,
+					key{"obfuscate.http", "other"}: 0.8,
+					key{"some-service", ""}:        0.8,
+				},
+			},
+		} {
+			assert.NoError(ps.readRatesJSON(ioutil.NopCloser(strings.NewReader(tt.in))))
+			for k, v := range tt.out {
+				assert.Equal(v, ps.getRate(mkSpan(k.service, k.env)), k)
+			}
+		}
+	})
+
+	t.Run("race", func(t *testing.T) {
+		ps := newPrioritySampler()
+		assert := assert.New(t)
+
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				assert.NoError(ps.readRatesJSON(
+					ioutil.NopCloser(strings.NewReader(
+						`{
+							"rate_by_service":{
+								"service:,env:":0.8,
+								"service:obfuscate.http,env:none":0.9
+							}
+						}`,
+					)),
+				))
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				ps.getRate(mkSpan("obfuscate.http", "none"))
+				ps.getRate(mkSpan("other.service", "none"))
+			}
+		}()
+
+		wg.Wait()
+	})
+
+	t.Run("apply", func(t *testing.T) {
+		ps := newPrioritySampler()
+		assert := assert.New(t)
+		assert.NoError(ps.readRatesJSON(
+			ioutil.NopCloser(strings.NewReader(
+				`{
+					"rate_by_service":{
+						"service:obfuscate.http,env:":0.5,
+						"service:obfuscate.http,env:none":0.5
+					}
+				}`,
+			)),
+		))
+
+		testSpan1 := &ddSpan{
+			Name:    "http.request",
+			Metrics: map[string]float64{},
+		}
+		testSpan1.Service = "obfuscate.http"
+		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 4)
+
+		ps.apply(testSpan1)
+		assert.EqualValues(ext.PriorityAutoKeep, testSpan1.Metrics[samplingPriorityKey])
+		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+
+		testSpan1.TraceID = math.MaxUint64 - (math.MaxUint64 / 3)
+		ps.apply(testSpan1)
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
+		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+
+		testSpan1.Service = "other-service"
+		testSpan1.TraceID = 1
+		assert.EqualValues(ext.PriorityAutoReject, testSpan1.Metrics[samplingPriorityKey])
+		assert.EqualValues(0.5, testSpan1.Metrics[samplingPriorityRateKey])
+	})
+}

--- a/span.go
+++ b/span.go
@@ -66,7 +66,7 @@ func (e *traceExporter) convertSpan(s *trace.SpanData) *ddSpan {
 	case trace.SpanKindServer:
 		span.Type = "server"
 	}
-	statusKey := statusDescriptionKey
+	statusKey := keyStatusDescription
 	if code := s.Status.Code; code != 0 {
 		statusKey = ext.ErrorMsg
 		span.Error = 1
@@ -85,10 +85,10 @@ func (e *traceExporter) convertSpan(s *trace.SpanData) *ddSpan {
 }
 
 const (
-	samplingPriorityKey     = "_sampling_priority_v1"
-	statusDescriptionKey    = "opencensus.status_description"
-	spanNameKey             = "span.name"
-	samplingPriorityRateKey = "_sampling_priority_rate_v1"
+	keySamplingPriority     = "_sampling_priority_v1"
+	keyStatusDescription    = "opencensus.status_description"
+	keySpanName             = "span.name"
+	keySamplingPriorityRate = "_sampling_priority_rate_v1"
 )
 
 func setTag(s *ddSpan, key string, val interface{}) {
@@ -108,7 +108,7 @@ func setTag(s *ddSpan, key string, val interface{}) {
 		}
 	case int64:
 		if key == ext.SamplingPriority {
-			s.Metrics[samplingPriorityKey] = float64(v)
+			s.Metrics[keySamplingPriority] = float64(v)
 		} else {
 			s.Metrics[key] = float64(v)
 		}
@@ -127,7 +127,7 @@ func setStringTag(s *ddSpan, key, v string) {
 		s.Resource = v
 	case ext.SpanType:
 		s.Type = v
-	case spanNameKey:
+	case keySpanName:
 		s.Name = v
 	default:
 		s.Meta[key] = v

--- a/span.go
+++ b/span.go
@@ -85,9 +85,10 @@ func (e *traceExporter) convertSpan(s *trace.SpanData) *ddSpan {
 }
 
 const (
-	samplingPriorityKey  = "_sampling_priority_v1"
-	statusDescriptionKey = "opencensus.status_description"
-	spanNameKey          = "span.name"
+	samplingPriorityKey     = "_sampling_priority_v1"
+	statusDescriptionKey    = "opencensus.status_description"
+	spanNameKey             = "span.name"
+	samplingPriorityRateKey = "_sampling_priority_rate_v1"
 )
 
 func setTag(s *ddSpan, key string, val interface{}) {

--- a/span.go
+++ b/span.go
@@ -54,7 +54,7 @@ func (e *traceExporter) convertSpan(s *trace.SpanData) *ddSpan {
 		Service:  e.opts.Service,
 		Start:    startNano,
 		Duration: s.EndTime.UnixNano() - startNano,
-		Metrics:  map[string]float64{samplingPriorityKey: ext.PriorityAutoKeep},
+		Metrics:  map[string]float64{},
 		Meta:     map[string]string{},
 	}
 	if s.ParentSpanID != (trace.SpanID{}) {

--- a/span_test.go
+++ b/span_test.go
@@ -53,11 +53,8 @@ var spanPairs = map[string]struct {
 			Resource: "/a/b",
 			Start:    testStartTime.UnixNano(),
 			Duration: testEndTime.UnixNano() - testStartTime.UnixNano(),
-			Metrics: map[string]float64{
-				"int64":             1,
-				samplingPriorityKey: ext.PriorityAutoKeep,
-			},
-			Service: "my-service",
+			Metrics:  map[string]float64{"int64": 1},
+			Service:  "my-service",
 			Meta: map[string]string{
 				"bool":               "true",
 				"str":                "abc",
@@ -89,11 +86,9 @@ var spanPairs = map[string]struct {
 			Resource: "/a/b",
 			Start:    testStartTime.UnixNano(),
 			Duration: testEndTime.UnixNano() - testStartTime.UnixNano(),
-			Metrics: map[string]float64{
-				samplingPriorityKey: ext.PriorityAutoKeep,
-			},
-			Service: "my-service",
-			Meta:    map[string]string{},
+			Metrics:  map[string]float64{},
+			Service:  "my-service",
+			Meta:     map[string]string{},
 		},
 	},
 	"error": {
@@ -121,11 +116,9 @@ var spanPairs = map[string]struct {
 			Resource: "/a/b",
 			Start:    testStartTime.UnixNano(),
 			Duration: testEndTime.UnixNano() - testStartTime.UnixNano(),
-			Metrics: map[string]float64{
-				samplingPriorityKey: ext.PriorityAutoKeep,
-			},
-			Error:   1,
-			Service: "my-service",
+			Metrics:  map[string]float64{},
+			Error:    1,
+			Service:  "my-service",
 			Meta: map[string]string{
 				ext.ErrorMsg:  "status-msg",
 				ext.ErrorType: "cancelled",

--- a/span_test.go
+++ b/span_test.go
@@ -58,7 +58,7 @@ var spanPairs = map[string]struct {
 			Meta: map[string]string{
 				"bool":               "true",
 				"str":                "abc",
-				statusDescriptionKey: "status-msg",
+				keyStatusDescription: "status-msg",
 			},
 		},
 	},
@@ -154,7 +154,7 @@ var spanPairs = map[string]struct {
 			Start:    testStartTime.UnixNano(),
 			Duration: testEndTime.UnixNano() - testStartTime.UnixNano(),
 			Metrics: map[string]float64{
-				samplingPriorityKey: ext.PriorityUserReject,
+				keySamplingPriority: ext.PriorityUserReject,
 			},
 			Service: "other-service",
 			Error:   1,
@@ -273,7 +273,7 @@ func TestSetTag(t *testing.T) {
 		setTag(span, "key", int64(12))
 		eq(span.Metrics["key"], float64(12))
 		setTag(span, ext.SamplingPriority, int64(1))
-		eq(span.Metrics[samplingPriorityKey], float64(1))
+		eq(span.Metrics[keySamplingPriority], float64(1))
 	})
 
 	t.Run("default", func(t *testing.T) {

--- a/trace.go
+++ b/trace.go
@@ -83,7 +83,7 @@ func (e *traceExporter) loop() {
 	for {
 		select {
 		case span := <-e.in:
-			if _, ok := span.Metrics[samplingPriorityKey]; !ok {
+			if _, ok := span.Metrics[keySamplingPriority]; !ok {
 				e.sampler.applyPriority(span)
 			}
 			if err := e.payload.add(span); err != nil {

--- a/trace_test.go
+++ b/trace_test.go
@@ -78,10 +78,8 @@ func TestTraceExporter(t *testing.T) {
 	t.Run("stop", func(t *testing.T) {
 		me := newTestTraceExporter(t)
 		me.exportSpan(spanPairs["root"].oc)
-
-		time.Sleep(time.Millisecond) // wait for recv
-
 		me.stop()
+
 		if len(me.payloads()) != 1 {
 			t.Fatalf("expected to flush 1, got %d", len(me.payloads()))
 		}
@@ -91,8 +89,6 @@ func TestTraceExporter(t *testing.T) {
 		eq := equalFunc(t)
 		me := newTestTraceExporter(t)
 		me.exportSpan(spanPairs["error"].oc)
-
-		time.Sleep(time.Millisecond) // wait for recv
 		me.stop()
 
 		// sampler is updated after flush

--- a/trace_test.go
+++ b/trace_test.go
@@ -107,11 +107,11 @@ func TestTraceExporter(t *testing.T) {
 
 		// span has sampling priority and rate applied
 		span1 := payload[0][0][0]
-		p, ok := span1.Metrics[samplingPriorityKey]
+		p, ok := span1.Metrics[keySamplingPriority]
 		if !ok || !(p == ext.PriorityAutoKeep || p == ext.PriorityAutoReject) {
 			t.Fatal(p, ok)
 		}
-		if v := span1.Metrics[samplingPriorityRateKey]; v != 1 {
+		if v := span1.Metrics[keySamplingPriorityRate]; v != 1 {
 			t.Fatalf("got %f", v)
 		}
 	})

--- a/trace_test.go
+++ b/trace_test.go
@@ -7,12 +7,16 @@ package datadog
 
 import (
 	"bytes"
+	"io"
+	"io/ioutil"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/tinylib/msgp/msgp"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 const (
@@ -82,6 +86,35 @@ func TestTraceExporter(t *testing.T) {
 			t.Fatalf("expected to flush 1, got %d", len(me.payloads()))
 		}
 	})
+
+	t.Run("sampler", func(t *testing.T) {
+		eq := equalFunc(t)
+		me := newTestTraceExporter(t)
+		me.exportSpan(spanPairs["error"].oc)
+
+		time.Sleep(time.Millisecond) // wait for recv
+		me.stop()
+
+		// sampler is updated after flush
+		eq(me.sampler.rates["service:db.users,env:"], 0.9)
+		eq(me.sampler.defaultRate, 0.8)
+
+		// got the sent span
+		payload := me.payloads()
+		eq(len(payload), 1)
+		eq(len(payload[0]), 1)
+		eq(len(payload[0][0]), 1)
+
+		// span has sampling priority and rate applied
+		span1 := payload[0][0][0]
+		p, ok := span1.Metrics[samplingPriorityKey]
+		if !ok || !(p == ext.PriorityAutoKeep || p == ext.PriorityAutoReject) {
+			t.Fatal(p, ok)
+		}
+		if v := span1.Metrics[samplingPriorityRateKey]; v != 1 {
+			t.Fatalf("got %f", v)
+		}
+	})
 }
 
 // testTraceExporter wraps a traceExporter, recording all flushed payloads.
@@ -107,7 +140,7 @@ func (me *testTraceExporter) payloads() []ddPayload {
 	return me.flushed
 }
 
-func (me *testTraceExporter) uploadFn(buf *bytes.Buffer, _ int) error {
+func (me *testTraceExporter) uploadFn(buf *bytes.Buffer, _ int) (io.ReadCloser, error) {
 	var ddp ddPayload
 	if err := msgp.Decode(buf, &ddp); err != nil {
 		me.t.Fatal(err)
@@ -115,5 +148,5 @@ func (me *testTraceExporter) uploadFn(buf *bytes.Buffer, _ int) error {
 	me.mu.Lock()
 	me.flushed = append(me.flushed, ddp)
 	me.mu.Unlock()
-	return nil
+	return ioutil.NopCloser(strings.NewReader(`{"rate_by_service":{"service:,env:":0.8,"service:db.users,env:":0.9}}`)), nil
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -53,6 +53,6 @@ func testSpan(traceID uint64, name, service string) *ddSpan {
 		Service:  service,
 		Start:    start,
 		Duration: duration,
-		Metrics:  map[string]float64{samplingPriorityKey: ext.PriorityAutoKeep},
+		Metrics:  map[string]float64{keySamplingPriority: ext.PriorityAutoKeep},
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -29,7 +29,11 @@ func TestTransport(t *testing.T) {
 		p.add(span)
 	}
 	trans := newTransport("")
-	err := trans.upload(p.buffer(), len(p.traces))
+	body, err := trans.upload(p.buffer(), len(p.traces))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = newPrioritySampler().readRatesJSON(body)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This change enables the use of the agent's /v0.4 endpoint and enables priority sampling by default.

`sampler.go` and `sampler_test.go` are copied from dd-trace-go@1.8.0