### PR TITLE
Add example for adding Datadog APM Metadata

### DIFF
--- a/examples/trace/main.go
+++ b/examples/trace/main.go
@@ -11,7 +11,7 @@ import (
 
 	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
 	"go.opencensus.io/trace"
-	ddtraceext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func bar(ctx context.Context) {
 
 	// Set Datadog APM Trace Metadata
 	span.AddAttributes(
-		trace.StringAttribute(ddtraceext.ResourceName, "my-app-resource"),
-		trace.StringAttribute(ddtraceext.SpanType, ddtraceext.SpanTypeWeb),
+		trace.StringAttribute(ext.ResourceName, "my-app-resource"),
+		trace.StringAttribute(ext.SpanType, ext.SpanTypeWeb),
 	)
 }

--- a/examples/trace/main.go
+++ b/examples/trace/main.go
@@ -11,6 +11,7 @@ import (
 
 	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
 	"go.opencensus.io/trace"
+	ddtraceext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 func main() {
@@ -37,4 +38,10 @@ func bar(ctx context.Context) {
 	defer span.End()
 
 	// Do bar...
+
+	// Set Datadog APM Trace Metadata
+	span.AddAttributes(
+		trace.StringAttribute(ddtraceext.ResourceName, "my-app-resource"),
+		// trace.StringAttribute(ddtraceext.SpanType, ddtraceext.SpanTypeWeb),
+	)
 }

--- a/examples/trace/main.go
+++ b/examples/trace/main.go
@@ -41,7 +41,7 @@ func bar(ctx context.Context) {
 
 	// Set Datadog APM Trace Metadata
 	span.AddAttributes(
-		trace.StringAttribute(ext.ResourceName, "my-app-resource"),
+		trace.StringAttribute(ext.ResourceName, "/foo/bar"),
 		trace.StringAttribute(ext.SpanType, ext.SpanTypeWeb),
 	)
 }

--- a/examples/trace/main.go
+++ b/examples/trace/main.go
@@ -42,6 +42,6 @@ func bar(ctx context.Context) {
 	// Set Datadog APM Trace Metadata
 	span.AddAttributes(
 		trace.StringAttribute(ddtraceext.ResourceName, "my-app-resource"),
-		// trace.StringAttribute(ddtraceext.SpanType, ddtraceext.SpanTypeWeb),
+		trace.StringAttribute(ddtraceext.SpanType, ddtraceext.SpanTypeWeb),
 	)
 }


### PR DESCRIPTION
Addresses my confusion about how to add Datadog APM Trace Metadata as demonstrated in #29 and #25.
i.e. use OpenCensus Attributes, not OpenCensus Tags to populate Datadog APM Trace Metadata

Also, use this example to point out special Datadog APM Trace Metadata as mentioned in #9 e.g. `span.type` is consumed by Datadog APM.