### PR TITLE
trace: add support for float64

### DIFF
--- a/span.go
+++ b/span.go
@@ -99,23 +99,28 @@ func setTag(s *ddSpan, key string, val interface{}) {
 	switch v := val.(type) {
 	case string:
 		setStringTag(s, key, v)
-		return
 	case bool:
 		if v {
-			s.Meta[key] = "true"
+			setStringTag(s, key, "true")
 		} else {
-			s.Meta[key] = "false"
+			setStringTag(s, key, "false")
 		}
+	case float64:
+		setMetric(s, key, v)
 	case int64:
-		if key == ext.SamplingPriority {
-			s.Metrics[keySamplingPriority] = float64(v)
-		} else {
-			s.Metrics[key] = float64(v)
-		}
+		setMetric(s, key, float64(v))
 	default:
 		// should never happen according to docs, nevertheless
 		// we should account for this to avoid exceptions
-		s.Meta[key] = fmt.Sprintf("%v", v)
+		setStringTag(s, key, fmt.Sprintf("%v", v))
+	}
+}
+
+func setMetric(s *ddSpan, key string, v float64) {
+	if key == ext.SamplingPriority {
+		s.Metrics[keySamplingPriority] = v
+	} else {
+		s.Metrics[key] = v
 	}
 }
 

--- a/span_test.go
+++ b/span_test.go
@@ -276,6 +276,15 @@ func TestSetTag(t *testing.T) {
 		eq(span.Metrics[keySamplingPriority], float64(1))
 	})
 
+	t.Run("float64", func(t *testing.T) {
+		eq := equalFunc(t)
+		span := testSpan()
+		setTag(span, "key", float64(12))
+		eq(span.Metrics["key"], float64(12))
+		setTag(span, ext.SamplingPriority, float64(1))
+		eq(span.Metrics[keySamplingPriority], float64(1))
+	})
+
 	t.Run("default", func(t *testing.T) {
 		span := testSpan()
 		setTag(span, "key", 1)


### PR DESCRIPTION
Adds support for `float64`, added in census-instrumentation/opencensus-go#1033

Closes #37