### PR TITLE
trace: add support for Trace Analytics

### DIFF
--- a/span.go
+++ b/span.go
@@ -117,9 +117,10 @@ func setTag(s *ddSpan, key string, val interface{}) {
 }
 
 func setMetric(s *ddSpan, key string, v float64) {
-	if key == ext.SamplingPriority {
+	switch key {
+	case ext.SamplingPriority:
 		s.Metrics[keySamplingPriority] = v
-	} else {
+	default:
 		s.Metrics[key] = v
 	}
 }
@@ -132,6 +133,12 @@ func setStringTag(s *ddSpan, key, v string) {
 		s.Resource = v
 	case ext.SpanType:
 		s.Type = v
+	case ext.AnalyticsEvent:
+		if v != "false" {
+			setMetric(s, ext.EventSampleRate, 1)
+		} else {
+			setMetric(s, ext.EventSampleRate, 0)
+		}
 	case keySpanName:
 		s.Name = v
 	default:

--- a/span_test.go
+++ b/span_test.go
@@ -265,6 +265,10 @@ func TestSetTag(t *testing.T) {
 		eq(span.Meta["key"], "true")
 		setTag(span, "key2", false)
 		eq(span.Meta["key2"], "false")
+		setTag(span, ext.AnalyticsEvent, true)
+		eq(span.Metrics[ext.EventSampleRate], 1.)
+		setTag(span, ext.AnalyticsEvent, false)
+		eq(span.Metrics[ext.EventSampleRate], 0.)
 	})
 
 	t.Run("int64", func(t *testing.T) {
@@ -283,6 +287,8 @@ func TestSetTag(t *testing.T) {
 		eq(span.Metrics["key"], float64(12))
 		setTag(span, ext.SamplingPriority, float64(1))
 		eq(span.Metrics[keySamplingPriority], float64(1))
+		setTag(span, ext.EventSampleRate, float64(0.4))
+		eq(span.Metrics[ext.EventSampleRate], float64(0.4))
 	})
 
 	t.Run("default", func(t *testing.T) {


### PR DESCRIPTION
This change adds support for the Datadog Trace Analytics tags by means of new attributes:

* [`ext.AnalyticsEvent`](https://github.com/DataDog/dd-trace-go/blob/v1/ddtrace/ext/tags.go#L67-L69) (bool): determines whether the span should be marked as an APM event. It is equivalent to setting the rate (see next bullet point) to `1.0`.
* [`ext.EventSampleRate`](https://github.com/DataDog/dd-trace-go/blob/v1/ddtrace/ext/tags.go#L63-L65) (float64): determines the rate at which the even should be sampled (0-1).

Updates #39 