### PR TITLE
Add option for percentiles to be emitted by client for distribution metrics

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -73,6 +73,19 @@ type Options struct {
 	// GlobalTags holds a set of tags that will automatically be applied to all
 	// exported spans.
 	GlobalTags map[string]interface{}
+
+	// DistributionMetricOptions configures distribution metrics
+	DistributionMetricOptions
+}
+
+// DistributionMetricOptions contain options for configuring how distribution metrics are emitted to DataDog
+type DistributionMetricOptions struct {
+	// DisableCountPerBuckets specifies whether to emit count_per_bucket metrics
+	DisableCountPerBuckets bool
+
+	// EmitPercentiles given a list of percentiles [0.5, 0.95, 0.99], for each one will estimate the percentile
+	// from the Distribution metric and emit a unique metric for each
+	EmitPercentiles []float64
 }
 
 func (o *Options) onError(err error) {

--- a/datadog.go
+++ b/datadog.go
@@ -6,6 +6,7 @@
 package datadog
 
 import (
+	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -85,7 +86,37 @@ type DistributionMetricOptions struct {
 
 	// EmitPercentiles given a list of percentiles [0.5, 0.95, 0.99], for each one will estimate the percentile
 	// from the Distribution metric and emit a unique metric for each
-	EmitPercentiles []float64
+	//
+	// Example: []Percentile{{0.5, "50p"},{0.95, "95p"}, {0.99, "99p"}}
+	EmitPercentiles []Percentile
+}
+
+// Percentile indicates the percentile to calculate for a distribution metric and its corresponding name
+type Percentile struct {
+	// Percentile must be in range [0, 100].
+	Percentile float64
+
+	// MetricSuffix (optional) controls the suffix of the metric name that is emitted. If not provided,
+	// will be formatted to 2 decimal places.
+	//
+	// Example: "99p" would emit `server_latency.99p if the distribution metric name was server_latency
+	MetricSuffix string
+}
+
+// Commonly used percentiles
+var (
+	Percentile50th  = Percentile{Percentile: 0.5, MetricSuffix: "median"}
+	Percentile75th  = Percentile{Percentile: 0.75, MetricSuffix: "75p"}
+	Percentile95th  = Percentile{Percentile: 0.95, MetricSuffix: "95p"}
+	Percentile99th  = Percentile{Percentile: 0.99, MetricSuffix: "99p"}
+	Percentile999th = Percentile{Percentile: 0.999, MetricSuffix: "999p"}
+)
+
+func (p Percentile) buildMetricSuffix() string {
+	if p.MetricSuffix != "" {
+		return p.MetricSuffix
+	}
+	return fmt.Sprintf("%.2fp", p.Percentile*100)
 }
 
 func (o *Options) onError(err error) {

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -272,3 +272,46 @@ func TestHistogram(t *testing.T) {
 		t.Errorf("Expected: %v, Got: %v\n", vd, actual)
 	}
 }
+
+func TestPercentile_buildMetricSuffix(t *testing.T) {
+	tsts := []struct {
+		Percentile
+		Expected string
+	}{
+		// Common
+		{
+			Percentile50th,
+			"median",
+		},
+		{
+			Percentile75th,
+			"75p",
+		},
+		{
+			Percentile95th,
+			"95p",
+		},
+		{
+			Percentile99th,
+			"99p",
+		},
+		{
+			Percentile999th,
+			"999p",
+		},
+		// Formatted
+		{
+			Percentile{Percentile: 0.92},
+			"92.00p",
+		},
+	}
+
+	for _, tst := range tsts {
+		t.Run("", func(t *testing.T) {
+			got := tst.buildMetricSuffix()
+			if got != tst.Expected {
+				t.Errorf("Expected: %v, Got %v\n", tst.Expected, got)
+			}
+		})
+	}
+}

--- a/stats.go
+++ b/stats.go
@@ -94,7 +94,7 @@ func (s *statsExporter) submitMetric(v *view.View, row *view.Row, metricName str
 			"squared_dev_sum": data.SumOfSquaredDev,
 		}
 		for _, percentile := range s.opts.EmitPercentiles {
-			metrics[fmt.Sprintf("%fp", percentile*100)] = calculatePercentile(percentile, v.Aggregation.Buckets, data.CountPerBucket)
+			metrics[percentile.buildMetricSuffix()] = calculatePercentile(percentile.Percentile, v.Aggregation.Buckets, data.CountPerBucket)
 		}
 
 		for name, value := range metrics {

--- a/stats_test.go
+++ b/stats_test.go
@@ -7,6 +7,7 @@ package datadog
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -102,4 +103,85 @@ func TestNilAggregation(t *testing.T) {
 	if actual == nil {
 		t.Errorf("Expected: %v, Got: %v", fmt.Errorf("aggregation *view.Aggregation is not supported"), actual)
 	}
+}
+
+func Test_calculatePercentile(t *testing.T) {
+	var buckets []float64
+	for i := float64(-100); i < 100; i += 0.1 {
+		buckets = append(buckets, i)
+	}
+
+	normalDistribution := calculateNormalDistribution(buckets, 0, 100)
+	tsts := []struct {
+		description     string
+		expected        int64
+		percentile      float64
+		buckets         []float64
+		countsPerBucket []int64
+	}{
+		{
+			"Calculates 50th percentile for normal distribution",
+			0,
+			0.5,
+			buckets,
+			normalDistribution,
+		},
+		{
+			"Calculates 75th percentile for normal distribution",
+			44,
+			0.75,
+			buckets,
+			normalDistribution,
+		},
+		{
+			"Calculates 95th percentile for normal distribution",
+			86,
+			0.95,
+			buckets,
+			normalDistribution,
+		},
+		{
+			"Calculates 99th percentile for normal distribution",
+			97,
+			0.99,
+			buckets,
+			normalDistribution,
+		},
+		{
+			"Calculates 99.9th percentile for normal distribution",
+			99,
+			0.999,
+			buckets,
+			normalDistribution,
+		},
+	}
+
+	for _, tst := range tsts {
+		t.Run(tst.description, func(t *testing.T) {
+			got := calculatePercentile(tst.percentile, tst.buckets, tst.countsPerBucket)
+
+			if tst.expected != int64(got) {
+				t.Errorf("Expected: %v, Got: %v", tst.expected, got)
+			}
+		})
+
+	}
+}
+
+func calculateNormalDistribution(buckets []float64, seed int64, standardDeviation float64) []int64 {
+	r := rand.New(rand.NewSource(seed))
+
+	normalDistribution := make([]int64, len(buckets))
+	for n := 0; n < 1e6; n++ {
+		rnd := r.NormFloat64() * standardDeviation
+		var previousBucket float64
+		for bidx, bucket := range buckets {
+			if rnd > previousBucket && rnd <= bucket {
+				normalDistribution[bidx]++
+				break
+			}
+			previousBucket = bucket
+		}
+	}
+	return normalDistribution
 }


### PR DESCRIPTION
Datadog doesn't support Distribution metrics at the API layer, this PR introduces the ability for each client to calculate the percentiles locally and emit them as a gauge metric. This PR also adds an option to disable emitting Counts Per Buckets which for us is not useful and is quite expensive due to the number of tags that are emitted.

Fixes #17 