### PR TITLE
trace: avoid data race when stop is called on traceExporter

### DIFF
--- a/msgpack.go
+++ b/msgpack.go
@@ -13,6 +13,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/tinylib/msgp/msgp"
 )
@@ -54,6 +55,7 @@ type payload struct {
 	// headerlessSize specifies the size of the payload in bytes, excluding the header
 	// which can range between 1 to 5 bytes, depending on len(traces).
 	headerlessSize int
+	mux            sync.Mutex
 }
 
 func newPayload() *payload {
@@ -62,6 +64,8 @@ func newPayload() *payload {
 
 // reset resets the payload, making it ready to use for a new buffer.
 func (p *payload) reset() {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 	p.traces = make(map[uint64]*packedSpans)
 	p.headerlessSize = 0
 }
@@ -69,11 +73,15 @@ func (p *payload) reset() {
 // size returns the number of bytes that the resulting payload would occupy given
 // the current state.
 func (p *payload) size() int {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 	return p.headerlessSize + arrayHeaderSize(uint64(len(p.traces)))
 }
 
 // add adds the given span to the payload.
 func (p *payload) add(span *ddSpan) error {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 	if uint(len(p.traces)) >= maxLength {
 		return errOverflow
 	}
@@ -92,6 +100,8 @@ func (p *payload) add(span *ddSpan) error {
 
 // buffer creates a copy of the msgpack-encoded payload and returns it.
 func (p *payload) buffer() *bytes.Buffer {
+	p.mux.Lock()
+	defer p.mux.Unlock()
 	var (
 		buf    bytes.Buffer
 		header [8]byte

--- a/trace.go
+++ b/trace.go
@@ -84,11 +84,14 @@ func (e *traceExporter) exportSpan(s *trace.SpanData) {
 	}
 }
 
+// Loop listens on exit channel to flush any remaining spans to the transport
+// and reporting any errors.
 func (e *traceExporter) loop() {
 	defer close(e.exit)
 	tick := time.NewTicker(flushInterval)
 	defer tick.Stop()
 
+loop:
 	for {
 		select {
 		case span := <-e.in:
@@ -98,12 +101,23 @@ func (e *traceExporter) loop() {
 			e.flush()
 
 		case <-e.exit:
-			e.flush()
-			e.wg.Wait() // wait for uploads to finish
-			e.errors.flush()
-			return
+			break loop
 		}
 	}
+
+	// drain the input channel to catch anything the loop might not process
+	drained := false
+	for !drained {
+		select {
+		case span := <-e.in:
+			e.receiveSpan(span)
+		default:
+			drained = true
+		}
+	}
+	e.flush()
+	e.wg.Wait() // wait for uploads to finish
+	e.errors.flush()
 }
 
 func (e *traceExporter) receiveSpan(span *ddSpan) {
@@ -137,21 +151,12 @@ func (e *traceExporter) flush() {
 	e.payload.reset()
 }
 
-// stop cleanly stops the exporter, flushing any remaining spans to the transport and
-// reporting any errors. Make sure to always call Stop at the end of your program in
-// order to not lose any tracing data. Only call Stop once per exporter. Repeated calls
-// will cause panic.
+// Stop help cleanly stops the exporter by sending to channel exit,
+// which will trigger loop to do the action.
+// Make sure to always call Stop at the end of your program
+// in order to not lose any tracing data.
+// Only call Stop once per exporter. Repeated calls will cause panic.
 func (e *traceExporter) stop() {
-loop:
-	// drain the input channel to catch anything the loop might not
-	for {
-		select {
-		case span := <-e.in:
-			e.receiveSpan(span)
-		default:
-			break loop
-		}
-	}
 	e.exit <- struct{}{}
 	<-e.exit
 }

--- a/trace.go
+++ b/trace.go
@@ -84,7 +84,8 @@ func (e *traceExporter) exportSpan(s *trace.SpanData) {
 	}
 }
 
-// Loop listens on exit channel to flush any remaining spans to the transport
+// loop consumes the input channel and also listens on exit channel
+// to cleanly stop the exporter, flushing any remaining spans to the transport
 // and reporting any errors.
 func (e *traceExporter) loop() {
 	defer close(e.exit)
@@ -151,11 +152,10 @@ func (e *traceExporter) flush() {
 	e.payload.reset()
 }
 
-// Stop help cleanly stops the exporter by sending to channel exit,
-// which will trigger loop to do the action.
-// Make sure to always call Stop at the end of your program
-// in order to not lose any tracing data.
-// Only call Stop once per exporter. Repeated calls will cause panic.
+// stop() notify loop() via exit channel to cleanly stops the exporter.
+// Make sure to always call stop() at the end of your program in order to
+// not lose any tracing data. Only call stop() once per exporter.
+// Repeated calls will cause panic.
 func (e *traceExporter) stop() {
 	e.exit <- struct{}{}
 	<-e.exit

--- a/trace.go
+++ b/trace.go
@@ -152,7 +152,8 @@ func (e *traceExporter) flush() {
 	e.payload.reset()
 }
 
-// stop() notify loop() via exit channel to cleanly stops the exporter.
+// stop signals the loop goroutine to finish.
+// This blocks until the loop goroutine closes the exit channel.
 // Make sure to always call stop() at the end of your program in order to
 // not lose any tracing data. Only call stop() once per exporter.
 // Repeated calls will cause panic.

--- a/trace.go
+++ b/trace.go
@@ -154,9 +154,6 @@ func (e *traceExporter) flush() {
 
 // stop signals the loop goroutine to finish.
 // This blocks until the loop goroutine closes the exit channel.
-// Make sure to always call stop() at the end of your program in order to
-// not lose any tracing data. Only call stop() once per exporter.
-// Repeated calls will cause panic.
 func (e *traceExporter) stop() {
 	e.exit <- struct{}{}
 	<-e.exit


### PR DESCRIPTION
when I used this library in our production service, found this issue
```
WARNING: DATA RACE
Read at 0x00c0002d6f18 by main goroutine:
  github.com/DataDog/opencensus-go-exporter-datadog.(*payload).add()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/msgpack.go:89 +0x336
  github.com/DataDog/opencensus-go-exporter-datadog.(*traceExporter).receiveSpan()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/trace.go:113 +0xbe
  github.com/DataDog/opencensus-go-exporter-datadog.(*traceExporter).stop()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/trace.go:150 +0x48
  github.com/DataDog/opencensus-go-exporter-datadog.(*Exporter).Stop()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/datadog.go:47 +0x50
  ...

Previous write at 0x00c0002d6f18 by goroutine 125:
  github.com/DataDog/opencensus-go-exporter-datadog.(*payload).add()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/msgpack.go:89 +0x36d
  github.com/DataDog/opencensus-go-exporter-datadog.(*traceExporter).receiveSpan()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/trace.go:113 +0xbe
  github.com/DataDog/opencensus-go-exporter-datadog.(*traceExporter).loop()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/trace.go:95 +0x2e6

Goroutine 125 (running) created at:
  github.com/DataDog/opencensus-go-exporter-datadog.newTraceExporter()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/trace.go:73 +0x4a3
  github.com/DataDog/opencensus-go-exporter-datadog.NewExporter()
      /go/src/github.robot.car/cruise/air/vendor/github.com/DataDog/opencensus-go-exporter-datadog/datadog.go:98 +0xc1
  ...
```

Thinking `payload` should be synced by mutex.