### PR TITLE
stats: add config to disable count per bucket

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -73,6 +73,9 @@ type Options struct {
 	// GlobalTags holds a set of tags that will automatically be applied to all
 	// exported spans.
 	GlobalTags map[string]interface{}
+
+	// DisableCountPerBuckets specifies whether to emit count_per_bucket metrics
+	DisableCountPerBuckets bool
 }
 
 func (o *Options) onError(err error) {

--- a/stats.go
+++ b/stats.go
@@ -96,10 +96,11 @@ func (s *statsExporter) submitMetric(v *view.View, row *view.Row, metricName str
 		for name, value := range metrics {
 			err = client.Gauge(metricName+"."+name, value, opt.tagMetrics(row.Tags, tags), rate)
 		}
-
-		for x := range data.CountPerBucket {
-			addlTags := []string{"bucket_idx:" + fmt.Sprint(x)}
-			err = client.Gauge(metricName+".count_per_bucket", float64(data.CountPerBucket[x]), opt.tagMetrics(row.Tags, addlTags), rate)
+		if !s.opts.DisableCountPerBuckets {
+			for x := range data.CountPerBucket {
+				addlTags := []string{"bucket_idx:" + fmt.Sprint(x)}
+				err = client.Gauge(metricName+".count_per_bucket", float64(data.CountPerBucket[x]), opt.tagMetrics(row.Tags, addlTags), rate)
+			}
 		}
 		return err
 	default:

--- a/stats_test.go
+++ b/stats_test.go
@@ -38,7 +38,7 @@ func testExporter(opts Options) (*testStatsExporter, error) {
 	return &testStatsExporter{e}, nil
 }
 
-func createListenUDPConn(t *testing.T, addr string) (*net.UDPConn, error) {
+func listenUDP(addr string) (*net.UDPConn, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func TestUDSExportError(t *testing.T) {
 	}
 }
 func TestDistributionData(t *testing.T) {
-	conn, err := createListenUDPConn(t, "localhost:0")
+	conn, err := listenUDP("localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -128,7 +128,12 @@ func TestDistributionData(t *testing.T) {
 			{
 				Tags: []tag.Tag{},
 				Data: &view.DistributionData{
-					CountPerBucket: make([]int64, 3),
+					CountPerBucket:  []int64{0, 2, 3},
+					Min:             1,
+					Max:             5,
+					Mean:            3,
+					SumOfSquaredDev: 10,
+					Count:           15,
 				},
 			},
 		},
@@ -142,14 +147,14 @@ func TestDistributionData(t *testing.T) {
 		result := string(buffer[:n])
 
 		expectedResult := []string{
-			`fooCount.avg:0.000000|g`,
-			`fooCount.count:0.000000|g`,
+			`fooCount.avg:3.000000|g`,
+			`fooCount.count:15.000000|g`,
 			`fooCount.count_per_bucket:0.000000|g|#bucket_idx:0`,
-			`fooCount.count_per_bucket:0.000000|g|#bucket_idx:1`,
-			`fooCount.count_per_bucket:0.000000|g|#bucket_idx:2`,
-			`fooCount.max:0.000000|g`,
-			`fooCount.min:0.000000|g`,
-			`fooCount.squared_dev_sum:0.000000|g`,
+			`fooCount.count_per_bucket:2.000000|g|#bucket_idx:1`,
+			`fooCount.count_per_bucket:3.000000|g|#bucket_idx:2`,
+			`fooCount.max:5.000000|g`,
+			`fooCount.min:1.000000|g`,
+			`fooCount.squared_dev_sum:10.000000|g`,
 		}
 
 		results := strings.Split(result, "\n")
@@ -169,11 +174,11 @@ func TestDistributionData(t *testing.T) {
 		result := string(buffer[:n])
 
 		expectedResult := []string{
-			`fooCount.avg:0.000000|g`,
-			`fooCount.count:0.000000|g`,
-			`fooCount.max:0.000000|g`,
-			`fooCount.min:0.000000|g`,
-			`fooCount.squared_dev_sum:0.000000|g`,
+			`fooCount.avg:3.000000|g`,
+			`fooCount.count:15.000000|g`,
+			`fooCount.max:5.000000|g`,
+			`fooCount.min:1.000000|g`,
+			`fooCount.squared_dev_sum:10.000000|g`,
 		}
 
 		results := strings.Split(result, "\n")

--- a/stats_test.go
+++ b/stats_test.go
@@ -107,21 +107,6 @@ func TestDistributionData(t *testing.T) {
 
 	addr := conn.LocalAddr().String()
 
-	exporterCount, err := testExporter(Options{
-		StatsAddr: addr,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	exporterNoCount, err := testExporter(Options{
-		StatsAddr:              addr,
-		DisableCountPerBuckets: true,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	client, err := statsd.NewBuffered(addr, 100)
 	if err != nil {
 		t.Fatal(err)
@@ -145,8 +130,14 @@ func TestDistributionData(t *testing.T) {
 	}
 
 	t.Run("ok", func(t *testing.T) {
-		exporterCount.client = client
-		exporterCount.statsExporter.addViewData(data)
+		exporter, err := testExporter(Options{
+			StatsAddr: addr,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		exporter.client = client
+		exporter.statsExporter.addViewData(data)
 
 		buffer := make([]byte, 4096)
 		n, err := io.ReadAtLeast(conn, buffer, 1)
@@ -176,8 +167,15 @@ func TestDistributionData(t *testing.T) {
 	})
 
 	t.Run("count per buckets disabled", func(t *testing.T) {
-		exporterNoCount.client = client
-		exporterNoCount.statsExporter.addViewData(data)
+		exporter, err := testExporter(Options{
+			StatsAddr:              addr,
+			DisableCountPerBuckets: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		exporter.client = client
+		exporter.statsExporter.addViewData(data)
 
 		buffer := make([]byte, 4096)
 		n, err := io.ReadAtLeast(conn, buffer, 1)

--- a/stats_test.go
+++ b/stats_test.go
@@ -163,8 +163,8 @@ func TestDistributionData(t *testing.T) {
 		},
 	}
 
-	for caseName, tc := range testCases {
-		t.Run(caseName, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			exporter, err := testExporter(tc.Options)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
# Description 

Add config to disable count per bucket

# Motivation

Initial request: 

> This PR also adds an option to disable emitting Counts Per Buckets which for us is not useful and is quite expensive due to the number of tags that are emitted.

https://github.com/DataDog/opencensus-go-exporter-datadog/pull/41
