### PR TITLE
stats: fix `TestUDSExportError` and test submit metric error

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -70,11 +70,11 @@ func TestUDPExportError(t *testing.T) {
 	}
 }
 
-func TestUDSExportError(t *testing.T) {
+func TestSubmitMetricError(t *testing.T) {
 	var expected error
 
 	exporter, err := testExporter(Options{
-		StatsAddr: "unix:///invalid.socket", // Ideally we wwouln't hit the filesystem.
+		StatsAddr: "unix:///dummy.socket",
 		OnError: func(err error) {
 			expected = err
 		},
@@ -88,7 +88,7 @@ func TestUDSExportError(t *testing.T) {
 		Rows: []*view.Row{
 			{
 				Tags: []tag.Tag{},
-				Data: &view.CountData{},
+				Data: nil,
 			},
 		},
 	}


### PR DESCRIPTION
`TestUDSExportError` was failing due to changes in https://github.com/DataDog/datadog-go/pull/91, it does not guarantee anymore to return error if we pass an invalid socket (the call is async). cc @arbll 

I changed the test to tests the submit metric instead: 

https://github.com/DataDog/opencensus-go-exporter-datadog/blob/fe3fae706db1cdb6dd6c97b838c57637c15cfbbc/stats.go#L107