### PR TITLE
Remove tags from metric names

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -123,10 +123,7 @@ func sanitizeMetricName(namespace string, v *view.View) string {
 
 // viewSignature creates the view signature with custom namespace
 func viewSignature(namespace string, v *view.View) string {
-	var buf strings.Builder
-	buf.WriteString(sanitizeMetricName(namespace, v))
-
-	return buf.String()
+	return sanitizeMetricName(namespace, v)
 }
 
 // tagMetrics concatenates user input custom tags with row tags

--- a/datadog.go
+++ b/datadog.go
@@ -125,9 +125,7 @@ func sanitizeMetricName(namespace string, v *view.View) string {
 func viewSignature(namespace string, v *view.View) string {
 	var buf strings.Builder
 	buf.WriteString(sanitizeMetricName(namespace, v))
-	for _, k := range v.TagKeys {
-		buf.WriteString("_" + k.Name())
-	}
+
 	return buf.String()
 }
 

--- a/datadog.go
+++ b/datadog.go
@@ -77,6 +77,9 @@ type Options struct {
 
 	// DisableCountPerBuckets specifies whether to emit count_per_bucket metrics
 	DisableCountPerBuckets bool
+
+	// Disable tags in metric name
+	DisableTagMetricName bool
 }
 
 func (o *Options) onError(err error) {
@@ -122,7 +125,16 @@ func sanitizeMetricName(namespace string, v *view.View) string {
 }
 
 // viewSignature creates the view signature with custom namespace
-func viewSignature(namespace string, v *view.View) string {
+func viewSignature(namespace string, disableTagMetricName bool, v *view.View) string {
+	if !disableTagMetricName {
+		var buf strings.Builder
+		buf.WriteString(sanitizeMetricName(namespace, v))
+		for _, k := range v.TagKeys {
+			buf.WriteString("_" + k.Name())
+		}
+		return buf.String()
+	}
+
 	return sanitizeMetricName(namespace, v)
 }
 

--- a/datadog.go
+++ b/datadog.go
@@ -78,8 +78,8 @@ type Options struct {
 	// DisableCountPerBuckets specifies whether to emit count_per_bucket metrics
 	DisableCountPerBuckets bool
 
-	// Disable tags in metric name
-	DisableTagMetricName bool
+	// TagMetricNames specifies whether to include tags to metric names.
+	TagMetricNames bool
 }
 
 func (o *Options) onError(err error) {
@@ -125,8 +125,8 @@ func sanitizeMetricName(namespace string, v *view.View) string {
 }
 
 // viewSignature creates the view signature with custom namespace
-func viewSignature(namespace string, disableTagMetricName bool, v *view.View) string {
-	if !disableTagMetricName {
+func viewSignature(namespace string, tagMetricNames bool, v *view.View) string {
+	if tagMetricNames {
 		var buf strings.Builder
 		buf.WriteString(sanitizeMetricName(namespace, v))
 		for _, k := range v.TagKeys {

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -120,7 +120,7 @@ func TestSignatureNoTag(t *testing.T) {
 	tags := append(testTags, key)
 	vd := newCustomView("fooGauge", view.Count(), tags, measureCount)
 
-	res := viewSignature(namespace, true, vd)
+	res := viewSignature(namespace, false, vd)
 	exp := "opencensus.fooGauge"
 	if res != exp {
 		t.Errorf("Expected: %v, Got: %v\n", exp, res)
@@ -133,7 +133,7 @@ func TestSignatureTag(t *testing.T) {
 	tags := append(testTags, key)
 	vd := newCustomView("fooCount", view.Count(), tags, measureCount)
 
-	res := viewSignature(namespace, false, vd)
+	res := viewSignature(namespace, true, vd)
 	exp := "datadog.fooCount_tag1"
 	if res != exp {
 		t.Errorf("Expected: %v, Got: %v\n", exp, res)

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -121,7 +121,7 @@ func TestSignature(t *testing.T) {
 	vd := newCustomView("fooGauge", view.Count(), tags, measureCount)
 
 	res := viewSignature(namespace, vd)
-	exp := "opencensus.fooGauge_signature"
+	exp := "opencensus.fooGauge"
 	if res != exp {
 		t.Errorf("Expected: %v, Got: %v\n", exp, res)
 	}

--- a/datadog_test.go
+++ b/datadog_test.go
@@ -114,14 +114,27 @@ func TestSanitizeMetricName(t *testing.T) {
 	}
 }
 
-func TestSignature(t *testing.T) {
+func TestSignatureNoTag(t *testing.T) {
 	key, _ := tag.NewKey("signature")
 	namespace := "opencensus"
 	tags := append(testTags, key)
 	vd := newCustomView("fooGauge", view.Count(), tags, measureCount)
 
-	res := viewSignature(namespace, vd)
+	res := viewSignature(namespace, true, vd)
 	exp := "opencensus.fooGauge"
+	if res != exp {
+		t.Errorf("Expected: %v, Got: %v\n", exp, res)
+	}
+}
+
+func TestSignatureTag(t *testing.T) {
+	key, _ := tag.NewKey("tag1")
+	namespace := "datadog"
+	tags := append(testTags, key)
+	vd := newCustomView("fooCount", view.Count(), tags, measureCount)
+
+	res := viewSignature(namespace, false, vd)
+	exp := "datadog.fooCount_tag1"
 	if res != exp {
 		t.Errorf("Expected: %v, Got: %v\n", exp, res)
 	}

--- a/stats.go
+++ b/stats.go
@@ -51,7 +51,7 @@ func newStatsExporter(o Options) (*statsExporter, error) {
 }
 
 func (s *statsExporter) addViewData(vd *view.Data) {
-	sig := viewSignature(s.opts.Namespace, vd.View)
+	sig := viewSignature(s.opts.Namespace, s.opts.DisableTagMetricName, vd.View)
 	s.mu.Lock()
 	s.viewData[sig] = vd
 	s.mu.Unlock()

--- a/stats.go
+++ b/stats.go
@@ -51,7 +51,7 @@ func newStatsExporter(o Options) (*statsExporter, error) {
 }
 
 func (s *statsExporter) addViewData(vd *view.Data) {
-	sig := viewSignature(s.opts.Namespace, s.opts.DisableTagMetricName, vd.View)
+	sig := viewSignature(s.opts.Namespace, s.opts.TagMetricNames, vd.View)
 	s.mu.Lock()
 	s.viewData[sig] = vd
 	s.mu.Unlock()


### PR DESCRIPTION
Fixes https://github.com/DataDog/opencensus-go-exporter-datadog/issues/60

Adds option `TagMetricNames` (false by default), to determine whether to include tags in the metric namespace. 