### PR TITLE
trace: flag 4xx for unspecified span kind as error

### DIFF
--- a/span.go
+++ b/span.go
@@ -77,9 +77,11 @@ func (e *traceExporter) convertSpan(s *trace.SpanData) *ddSpan {
 		}
 	case trace.SpanKindServer:
 		span.Type = "server"
-		fallthrough
-	default:
 		if code.status/100 == 5 {
+			span.Error = 1
+		}
+	default:
+		if code.status/100 == 4 || code.status/100 == 5 {
 			span.Error = 1
 		}
 	}

--- a/span_test.go
+++ b/span_test.go
@@ -240,6 +240,43 @@ var spanPairs = map[string]struct {
 			},
 		},
 	},
+	"default_error_4xx": {
+		oc: &trace.SpanData{
+			SpanContext: trace.SpanContext{
+				TraceID:      trace.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}),
+				SpanID:       trace.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+				TraceOptions: 1,
+			},
+			SpanKind:   trace.SpanKindUnspecified,
+			Name:       "/a/b",
+			StartTime:  testStartTime,
+			EndTime:    testEndTime,
+			Attributes: map[string]interface{}{},
+			Status: trace.Status{
+				Code:    trace.StatusCodeCancelled,
+				Message: "status-msg",
+			},
+		},
+		dd: &ddSpan{
+			TraceID:  651345242494996240,
+			SpanID:   72623859790382856,
+			Type:     "",
+			Name:     "opencensus",
+			Resource: "/a/b",
+			Start:    testStartTime.UnixNano(),
+			Duration: testEndTime.UnixNano() - testStartTime.UnixNano(),
+			Metrics:  map[string]float64{},
+			Error:    1,
+			Service:  "my-service",
+			Meta: map[string]string{
+				ext.ErrorMsg:         "status-msg",
+				ext.ErrorType:        "CANCELLED",
+				keyStatus:            "CANCELLED",
+				keyStatusCode:        "1",
+				keyStatusDescription: "status-msg",
+			},
+		},
+	},
 	"tags": {
 		oc: &trace.SpanData{
 			SpanContext: trace.SpanContext{


### PR DESCRIPTION
Part of #62 

When the span kind is not specified, it can be a `server`, a `client` or both (see example in the issue).
In that case, the span should be flagged as an error when encountering **4xx** or **5xx**