### PR TITLE
stats: support datadog statsd options

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
@@ -80,6 +81,9 @@ type Options struct {
 
 	// TagMetricNames specifies whether to include tags to metric names.
 	TagMetricNames bool
+
+	// StatsdOptions defines a set of options to be passed to the statsd client.
+	StatsdOptions []statsd.Option
 }
 
 func (o *Options) onError(err error) {

--- a/stats.go
+++ b/stats.go
@@ -38,7 +38,7 @@ func newStatsExporter(o Options) (*statsExporter, error) {
 		endpoint = DefaultStatsAddrUDP
 	}
 
-	client, err := statsd.New(endpoint)
+	client, err := statsd.New(endpoint, o.StatsdOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -309,7 +309,7 @@ func TestStatsdOptions(t *testing.T) {
 		StatsdOptions: []statsd.Option{
 			// Payload size is enough for one metric only
 			statsd.WithMaxBytesPerPayload(payloadMaxSize),
-			statsd.WithNamespace("customnamespace"),
+			statsd.WithNamespace("customnamespace."),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Allow users to use all statsd options for the stats exporter.

Address #50 
Duplicate #48 